### PR TITLE
fix: Mail.add_header doesn't accept a dict

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -461,8 +461,13 @@ class Mail(object):
         """Add headers to the email globaly or to a specific Personalization
 
         :param value: A Header object or a dict of header key/values
+                      If dict has multiple keys, only first key/value item are applied
         :type value: Header, dict
         """
+        if isinstance(header, dict):
+            (k, v) = list(header.items())[0]
+            self._headers = self._ensure_append(Header(k, v), self._headers)
+            return
         if header.personalization is not None:
             try:
                 personalization = \
@@ -471,23 +476,14 @@ class Mail(object):
             except IndexError:
                 personalization = Personalization()
                 has_internal_personalization = False
-            if isinstance(header, dict):
-                (k, v) = list(header.items())[0]
-                personalization.add_header(Header(k, v))
-            else:
-                personalization.add_header(header)
+            personalization.add_header(header)
 
             if not has_internal_personalization:
                 self.add_personalization(
                     personalization,
                     index=header.personalization)
         else:
-            if isinstance(header, dict):
-                (k, v) = list(header.items())[0]
-                self._headers = self._ensure_append(
-                    Header(k, v), self._headers)
-            else:
-                self._headers = self._ensure_append(header, self._headers)
+            self._headers = self._ensure_append(header, self._headers)
 
     @property
     def substitution(self):

--- a/test/unit/test_mail_helpers.py
+++ b/test/unit/test_mail_helpers.py
@@ -2,6 +2,8 @@
 import json
 import unittest
 
+from sendgrid.helpers.mail.header import Header
+
 try:
     from email.message import EmailMessage
 except ImportError:
@@ -336,6 +338,142 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(
             message.get(),
             json.loads(response_content_with_all_three_mime_contents)
+        )
+
+    def test_single_email_with_custom_header_globaly(self):
+        from sendgrid.helpers.mail import (Mail, From, To, Subject,
+                                           Header, PlainTextContent)
+        self.maxDiff = None
+        message = Mail(
+            from_email=From('test+from@example.com', 'Example From Name'),
+            to_emails=To('test+to@example.com', 'Example To Name'),
+            subject=Subject('Sending with SendGrid is Fun'),
+            plain_text_content=PlainTextContent(
+                'and easy to do anywhere, even with Python')
+        )
+
+        message.header = Header('X-Test1', 'Test1')
+        response_content = json.dumps({
+            "content": [
+                {
+                    "type": "text/plain",
+                    "value": "and easy to do anywhere, even with Python"
+                }
+            ],
+            "from": {
+                "email": "test+from@example.com",
+                "name": "Example From Name"
+            },
+            "personalizations": [
+                {
+                    "to": [
+                        {
+                            "email": "test+to@example.com",
+                            "name": "Example To Name"
+                        }
+                    ]
+                }
+            ],
+            "subject": "Sending with SendGrid is Fun",
+            "headers": {
+                "X-Test1": "Test1"
+            }
+        })
+        self.assertEqual(
+            message.get(),
+            json.loads(response_content)
+        )
+
+    def test_single_email_with_custom_header_globaly_single_key_value_dict(self):
+        from sendgrid.helpers.mail import (Mail, From, To, Subject,
+                                           Header, PlainTextContent)
+        self.maxDiff = None
+        message = Mail(
+            from_email=From('test+from@example.com', 'Example From Name'),
+            to_emails=To('test+to@example.com', 'Example To Name'),
+            subject=Subject('Sending with SendGrid is Fun'),
+            plain_text_content=PlainTextContent(
+                'and easy to do anywhere, even with Python')
+        )
+        message.add_header({'X-Test1': 'Test1'})
+
+        response_content = json.dumps({
+            "content": [
+                {
+                    "type": "text/plain",
+                    "value": "and easy to do anywhere, even with Python"
+                }
+            ],
+            "from": {
+                "email": "test+from@example.com",
+                "name": "Example From Name"
+            },
+            "personalizations": [
+                {
+                    "to": [
+                        {
+                            "email": "test+to@example.com",
+                            "name": "Example To Name"
+                        }
+                    ]
+                }
+            ],
+            "subject": "Sending with SendGrid is Fun",
+            "headers": {
+                "X-Test1": "Test1"
+            }
+        })
+        self.assertEqual(
+            message.get(),
+            json.loads(response_content)
+        )
+
+    def test_single_email_with_custom_header_globaly_multi_key_values_dict(self):
+        from sendgrid.helpers.mail import (Mail, From, To, Subject,
+                                           Header, PlainTextContent)
+        self.maxDiff = None
+        message = Mail(
+            from_email=From('test+from@example.com', 'Example From Name'),
+            to_emails=To('test+to@example.com', 'Example To Name'),
+            subject=Subject('Sending with SendGrid is Fun'),
+            plain_text_content=PlainTextContent(
+                'and easy to do anywhere, even with Python')
+        )
+        message.add_header({
+            'X-Test1': 'Test1',
+            'X-Test2': 'Test2'
+        })
+
+        response_content = json.dumps({
+            "content": [
+                {
+                    "type": "text/plain",
+                    "value": "and easy to do anywhere, even with Python"
+                }
+            ],
+            "from": {
+                "email": "test+from@example.com",
+                "name": "Example From Name"
+            },
+            "personalizations": [
+                {
+                    "to": [
+                        {
+                            "email": "test+to@example.com",
+                            "name": "Example To Name"
+                        }
+                    ]
+                }
+            ],
+            "subject": "Sending with SendGrid is Fun",
+            "headers": {
+                "X-Test1": "Test1",
+                # "X-Test2": "Test2",  # does NOT applied
+            }
+        })
+        self.assertEqual(
+            message.get(),
+            json.loads(response_content)
         )
 
     def test_single_email_with_amp_and_html_contents_to_single_recipient(self):


### PR DESCRIPTION
Fixes #997

Headers are correctly added even if the argument of add_header is of type dict.

The current spec seems to intend that only the first key/value is added when a dict type argument is given. I couldn't figure out why this implementation.
I think the spec should apply to all keys/values that a dict argument has. The current spec is non-intuitive and confusing to users.

However, changes for supports to multiple key/value pairs could result in "breaking change", so the policy in this pull request was to keep changes to a minimum.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
